### PR TITLE
Update SessionProcessor.cs

### DIFF
--- a/EXOFiddlerInspector/CheckForAppUpdate.cs
+++ b/EXOFiddlerInspector/CheckForAppUpdate.cs
@@ -100,6 +100,11 @@ namespace EXOFiddlerInspector
                     "A new version is available v" + newVersion.Major + "." + newVersion.Minor + "." + newVersion.Build + "." + Environment.NewLine +
                     "Do you want to download the update?";
 
+                    FiddlerApplication.Prefs.SetStringPref("extensions.EXOFiddlerExtension.UpdateMessage", $"Update Available{Environment.NewLine}----------------" +
+                        $"{Environment.NewLine}Currently using version: {applicationVersion.Major}.{applicationVersion.Minor}.{applicationVersion.Build}" +
+                        $"{Environment.NewLine}New version available: {newVersion.Major}.{newVersion.Minor}.{newVersion.Build} {Environment.NewLine} {Environment.NewLine}" +
+                        $"Download the latest version: {Environment.NewLine}https://aka.ms/exofiddlerextension {Environment.NewLine} {Environment.NewLine}");
+
                     string caption = "EXO Fiddler Extension - Update Available";
 
                     /// <remarks>
@@ -134,6 +139,8 @@ namespace EXOFiddlerInspector
                 /// 
                 Debug.WriteLine($"EXCHANGE ONLINE EXTENSION: {DateTime.Now}: CheckForAppUpdate.cs : No update available.");
                 FiddlerApplication.Prefs.SetStringPref("extensions.EXOFiddlerExtension.MenuTitle", "Exchange Online");
+
+                FiddlerApplication.Prefs.SetStringPref("extensions.EXOFiddlerExtension.UpdateMessage", "");
 
                 if (bAppLoggingEnabled)
                 {

--- a/EXOFiddlerInspector/Inspectors/EXOInspector.cs
+++ b/EXOFiddlerInspector/Inspectors/EXOInspector.cs
@@ -237,6 +237,8 @@ namespace EXOFiddlerInspector.Inspectors
 
                 //this.Clear();
 
+                ResultsString.Append(FiddlerApplication.Prefs.GetStringPref("extensions.EXOFiddlerExtension.UpdateMessage", ""));
+
                 ResultsString.AppendLine("General Session Data");
                 ResultsString.AppendLine("--------------------");
                 ResultsString.AppendLine();

--- a/EXOFiddlerInspector/SessionProcessor.cs
+++ b/EXOFiddlerInspector/SessionProcessor.cs
@@ -32,6 +32,9 @@ namespace EXOFiddlerInspector
 
         public void Initialize()
         {
+            if (!Preferences.ExtensionEnabled)
+                return;
+
             FiddlerApplication.OnLoadSAZ += HandleLoadSaz;
 
             if (!IsInitialized)

--- a/EXOFiddlerInspector/SessionProcessor.cs
+++ b/EXOFiddlerInspector/SessionProcessor.cs
@@ -32,6 +32,7 @@ namespace EXOFiddlerInspector
 
         public void Initialize()
         {
+            // Stop HandleLoadSaz and further processing if the extension is not enabled.
             if (!Preferences.ExtensionEnabled)
                 return;
 
@@ -71,6 +72,10 @@ namespace EXOFiddlerInspector
             FiddlerApplication.UI.lvSessions.BeginUpdate();
 
             Preferences.IsLoadSaz = true;
+            
+            // HandleLoadSaz function was enabling the extension. 
+            // The drawback to this is that if the extension is disabled and a loadsaz event occurs the extension is re-enabled. This may not be what the user wants.
+
             //Preferences.ExtensionEnabled = true;
             MenuUI.Instance.miEnabled.Checked = Preferences.ExtensionEnabled;
 

--- a/EXOFiddlerInspector/SessionProcessor.cs
+++ b/EXOFiddlerInspector/SessionProcessor.cs
@@ -71,7 +71,7 @@ namespace EXOFiddlerInspector
             FiddlerApplication.UI.lvSessions.BeginUpdate();
 
             Preferences.IsLoadSaz = true;
-            Preferences.ExtensionEnabled = true;
+            //Preferences.ExtensionEnabled = true;
             MenuUI.Instance.miEnabled.Checked = Preferences.ExtensionEnabled;
 
             foreach (var session in e.arrSessions)

--- a/EXOFiddlerInspector/UI/ExchangeResponseControl.Designer.cs
+++ b/EXOFiddlerInspector/UI/ExchangeResponseControl.Designer.cs
@@ -44,6 +44,7 @@
             this.ResultsDisplay.Multiline = true;
             this.ResultsDisplay.Name = "ResultsDisplay";
             this.ResultsDisplay.ReadOnly = true;
+            this.ResultsDisplay.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.ResultsDisplay.Size = new System.Drawing.Size(558, 605);
             this.ResultsDisplay.TabIndex = 1;
             // 


### PR DESCRIPTION
1) return; to stop HandleLoadSaz and further processing if the extension is not enabled.
Fixes error on double clicking saz file with the extension disabled.

Is this the best fix available for this issue? Any drawbacks?

2) Commented out Preferences.ExtensionEnabled = true; in HandleLoadSaz.

This prevents unintentional ennoblement of the extension if a loadsaz event occurs. After testing on my system this looks good. Any drawbacks to this?